### PR TITLE
Update to Java 8 and bump dependency versions

### DIFF
--- a/influxdb-fetcher/pom.xml
+++ b/influxdb-fetcher/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.hgomez.influxdb</groupId>
   <artifactId>influxdb-fetcher</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.2-SNAPSHOT</version>
   <name>InfluxDB Fetcher</name>
   <description>Simple InfluxDB Fetcher</description>
 
   <properties>
-    <!-- Java 6 -->
-    <maven.compiler.source>6</maven.compiler.source>
-    <maven.compiler.target>6</maven.compiler.target>
+    <!-- Java 8 -->
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -30,7 +30,7 @@
   <developers>
     <developer>
       <name>Henri Gomez</name>
-      <email>henri.gomez@gmail.com.com</email>
+      <email>henri.gomez@gmail.com</email>
     </developer>
   </developers>
 
@@ -73,12 +73,12 @@
     <dependency>
       <groupId>org.influxdb</groupId>
       <artifactId>influxdb-java</artifactId>
-      <version>2.12</version>
+      <version>2.21</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.9.4</version>
+      <version>2.10.9</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Dear Henri,

thanks again for conceiving InfluxDB Fetcher, see #3. This patch updates the `pom.xml` file in order to support Java 7. We needed this to build and publish [`influxdb-fetcher-1.0.1.jar`](https://github.com/daq-tools/influxdb-fetcher/releases/download/1.0.1/influxdb-fetcher-1.0.1.jar).

With kind regards,
Andreas.
