### PR TITLE
Remove integer type detection heuristics; add support for boolean types

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ like `sed` to manipulate the content.
 # Fetch data.
 influxdb-fetcher ... > data.wireproto
 
-# Manipulate data: Rename field.
+# Manipulate schema: Rename field.
 sed -i -e "s/foo\=\([0-9.]*\)/bar=\1/g" data.wireproto
 
 # Manipulate data: Cast from Int64 to Float.
@@ -74,11 +74,6 @@ curl -u login:password -i -POST \
 
 * To get InfluxDB tags properly populated into line protocol format, you
   should add a `GROUP BY` clause.
-
-* The Java API returns numeric values as float. InfluxDB Fetcher will try
-  to figure out if numbers will be an Int64 (terminated by i in line protocol)
-  or a Float. Sometimes, a field may be falsly classified as Int64.
-  The `sed` example above might save you here.
 
 * By carefully crafting InfluxQL expressions (using `WHERE time=...`), you
   should be able to fetch data in batches, ideally 10K-20K at a time.

--- a/influxdb-fetcher/src/main/java/com/github/hgomez/influxdb/InfluxDBFetcher.java
+++ b/influxdb-fetcher/src/main/java/com/github/hgomez/influxdb/InfluxDBFetcher.java
@@ -133,6 +133,7 @@ public class InfluxDBFetcher {
         }
 
         // Add columns/values on line
+        boolean field_added = false;
         for (int i = 1; i < values.size(); i++) {
             Object value = values.get(i);
 
@@ -149,23 +150,28 @@ public class InfluxDBFetcher {
                     builderTags.append(escapeSpaceCommaString(value.toString()));
                 }
             } else {
-            	// We could get null values, in this case don't copy fieldname
+            	// We could get null values, in this case don't copy field name
             	if (value != null) {
+
+	                // Add virg if another field has been added beforehand
+	                if (field_added) {
+	                    builderFields.append(',');
+	                }
+
+	                // Add value
 	                if (value instanceof Double) {
 	                    builderFields.append(columns.get(i));
 	                    builderFields.append('=');
 	                    builderFields.append(generateNumeric((Double) value));
+	                    field_added = true;
 	                } else if (value instanceof String) {
 	                    builderFields.append(columns.get(i));
 	                    builderFields.append("=\"");
 	                    builderFields.append(escapeQuoteCRLFString(value.toString()));
 	                    builderFields.append('"');
+	                    field_added = true;
 	                }
 
-	                // Add virg if not latest value
-	                if (i != values.size() - 1) {
-	                    builderFields.append(',');
-	                }
             	}
             }
         }

--- a/influxdb-fetcher/src/main/java/com/github/hgomez/influxdb/InfluxDBFetcher.java
+++ b/influxdb-fetcher/src/main/java/com/github/hgomez/influxdb/InfluxDBFetcher.java
@@ -143,11 +143,20 @@ public class InfluxDBFetcher {
                 if (value instanceof Double) {
                     builderTags.append(escapeSpaceCommaString(columns.get(i)));
                     builderTags.append('=');
-                    builderTags.append(generateNumeric((Double) value));
+                    builderTags.append(value.toString());
+                } else if (value instanceof Integer) {
+                    builderTags.append(escapeSpaceCommaString(columns.get(i)));
+                    builderTags.append('=');
+                    builderTags.append(value.toString());
+                    builderTags.append('i');
                 } else if (value instanceof String) {
                     builderTags.append(escapeSpaceCommaString(columns.get(i)));
                     builderTags.append("=");
                     builderTags.append(escapeSpaceCommaString(value.toString()));
+                } else if (value instanceof Boolean) {
+                    builderTags.append(escapeSpaceCommaString(columns.get(i)));
+                    builderTags.append("=");
+                    builderTags.append(value.toString());
                 }
             } else {
             	// We could get null values, in this case don't copy field name
@@ -162,13 +171,24 @@ public class InfluxDBFetcher {
 	                if (value instanceof Double) {
 	                    builderFields.append(columns.get(i));
 	                    builderFields.append('=');
-	                    builderFields.append(generateNumeric((Double) value));
+	                    builderFields.append(value.toString());
+	                    field_added = true;
+	                } else if (value instanceof Integer) {
+	                    builderFields.append(columns.get(i));
+	                    builderFields.append('=');
+	                    builderFields.append(value.toString());
+	                    builderFields.append('i');
 	                    field_added = true;
 	                } else if (value instanceof String) {
 	                    builderFields.append(columns.get(i));
 	                    builderFields.append("=\"");
 	                    builderFields.append(escapeQuoteCRLFString(value.toString()));
 	                    builderFields.append('"');
+	                    field_added = true;
+	                } else if (value instanceof Boolean) {
+	                    builderFields.append(columns.get(i));
+                        builderFields.append('=');
+	                    builderFields.append(value.toString());
 	                    field_added = true;
 	                }
 
@@ -262,24 +282,4 @@ public class InfluxDBFetcher {
         return nStr;
     }
 
-    /**
-     * Generate a String for Numeric Value (in Double), could be Integers or
-     * Float (damn't protocol) Integer value are suffix by i
-     *
-     * @param pValue
-     * @return escaped String or original if nothing was required
-     */
-    public static String generateNumeric(Double pValue) {
-
-        StringBuilder builder = new StringBuilder();
-
-        if ((pValue == Math.rint(pValue))) {
-            builder.append(pValue.longValue());
-            builder.append('i');
-        } else {
-            builder.append(pValue);
-        }
-
-        return builder.toString();
-    }
 }


### PR DESCRIPTION
Dear Henri,

we prepared yet another patch to improve _InfluxDB Fetcher_.

> Apparently, with releases of InfluxDB>=1.0 and its Java driver, the heuristics applied to detect Integer types are not required anymore, see [1] at section "Checking field types".
>
> So, this adds native support for Integer types and, at the same time, it adds support for boolean types.
>
> [1] https://www.influxdata.com/blog/tldr-influxdb-tech-tips-june-2-2016/

The patch builds upon #9 and might supersede it.

With kind regards,
Andreas.
