### PR TITLE
Use MessagePack instead of JSON serialization

### DIFF
--- a/influxdb-fetcher/pom.xml
+++ b/influxdb-fetcher/pom.xml
@@ -75,11 +75,6 @@
       <artifactId>influxdb-java</artifactId>
       <version>2.21</version>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.10.9</version>
-    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Dear Henri.

Apparently, the default JSON serialization used under the hood when talking to InfluxDB had many flaws in the past and some of them might even hold true and can't be fixed. I found about about this when reading a bit into https://github.com/influxdata/influxdb-java/pull/671, https://github.com/influxdata/influxdb-java/issues/406, https://github.com/influxdata/influxdb-java/issues/153#issuecomment-259681987 and https://github.com/square/moshi/issues/192.

So, I would suggest to follow @fmachado's recommendation at https://github.com/influxdata/influxdb-java/issues/440#issuecomment-483896165:

> tl;dr: If you are using InfluxDB 1.4+, use the `ResponseFormat.MessagePack` when creating your InfluxDB client.

This patch implements just that.

With kind regards,
Andreas.