### PR TITLE
Improve README: Add another recipe for advanced schema manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ recommend to use Perl. Those are some examples which roughly outline the process
 
 ```sh
 # Fetch data.
-influxdb-fetcher ... > data.wireproto
+influxdb-fetcher ... > data.lineproto
 
 # Manipulate schema: Rename field.
-sed -i -e "s/foo\=\([0-9.]*\)/bar=\1/g" data.wireproto
+sed -i -e "s/foo\=\([0-9.]*\)/bar=\1/g" data.lineproto
 
 # Manipulate schema: Advanced field renaming with negative lookbehind.
 # This renames all fields not already prefixed with `SonoffSC.`.
@@ -69,15 +69,15 @@ perl -pi -e "
   s/(?<!SonoffSC\.)Noise/SonoffSC\.Noise/; \
   s/(?<!SonoffSC\.)Temperature/SonoffSC\.Temperature/; \
   " \
-  test_sonoffsc_sensors.lineproto
+  data.lineproto
 
 # Manipulate data: Cast from Int64 to Float.
-sed -i -e "s/value\=\([0-9]*\)i/value=\1/g" data.wireproto
+sed -i -e "s/value\=\([0-9]*\)i/value=\1/g" data.lineproto
 
 # Upload data to different destination.
 curl -u login:password -i -POST \
   "http://dest-influxdb.example.org:8086/write?db=new_db" \
-  --data-binary @data.wireproto
+  --data-binary @data.lineproto
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ influxdb-fetcher \
 ### Rename fields
 
 As the line protocol format is pure ASCII, it is easy to use standard Unix tools
-like `sed` to manipulate the content.
-
+like `sed` to manipulate the content. For more advanced manipulations, we
+recommend to use Perl. Those are some examples which roughly outline the process.
 
 ```sh
 # Fetch data.
@@ -60,13 +60,24 @@ influxdb-fetcher ... > data.wireproto
 # Manipulate schema: Rename field.
 sed -i -e "s/foo\=\([0-9.]*\)/bar=\1/g" data.wireproto
 
+# Manipulate schema: Advanced field renaming with negative lookbehind.
+# This renames all fields not already prefixed with `SonoffSC.`.
+perl -pi -e "
+  s/(?<!SonoffSC\.)AirQuality/SonoffSC\.AirQuality/; \
+  s/(?<!SonoffSC\.)Humidity/SonoffSC\.Humidity/; \
+  s/(?<!SonoffSC\.)Light/SonoffSC\.Light/; \
+  s/(?<!SonoffSC\.)Noise/SonoffSC\.Noise/; \
+  s/(?<!SonoffSC\.)Temperature/SonoffSC\.Temperature/; \
+  " \
+  test_sonoffsc_sensors.lineproto
+
 # Manipulate data: Cast from Int64 to Float.
 sed -i -e "s/value\=\([0-9]*\)i/value=\1/g" data.wireproto
 
 # Upload data to different destination.
 curl -u login:password -i -POST \
-    "http://dest-influxdb.example.org:8086/write?db=new_db" \
-    --data-binary @data.wireproto
+  "http://dest-influxdb.example.org:8086/write?db=new_db" \
+  --data-binary @data.wireproto
 ```
 
 


### PR DESCRIPTION
Hi again,

this is another little patch which improves the README file by adding a recipe we just used to rename some fields in an advanced manner.

As [negative lookbehinds](https://www.regular-expressions.info/lookaround.html#lookbehind) are required, using `sed` is not sufficient here.

```sh
perl -pi -e "
  s/(?<!SonoffSC\.)AirQuality/SonoffSC\.AirQuality/; \
  s/(?<!SonoffSC\.)Humidity/SonoffSC\.Humidity/; \
  s/(?<!SonoffSC\.)Light/SonoffSC\.Light/; \
  s/(?<!SonoffSC\.)Noise/SonoffSC\.Noise/; \
  s/(?<!SonoffSC\.)Temperature/SonoffSC\.Temperature/; \
  " \
  data.lineproto
```

The background of this is that we had to counter a breaking change within our data acquisition system for the [Tasmota firmware payload decoder](https://getkotori.org/docs/handbook/decoders/tasmota.html), see https://github.com/daq-tools/kotori/commit/012d67b7d. So, the field names within the lineprotocol file had to be aligned with the updated naming convention.

Negative lookbehinds were required because we already had both old and new records in the database, like:
```
test_sonoffsc_sensors AirQuality=90.0,Humidity=15.0,Light=10.0,Noise=10.0,Temperature=25.0 1559603736276810957
...
```

vs.

```
test_sonoffsc_sensors SonoffSC.AirQuality=80.0,SonoffSC.Humidity=92.0,SonoffSC.Light=10.0,SonoffSC.Noise=40.0,SonoffSC.Temperature=23.0 1614632659000000000
...
```

Not using negative lookbehinds here would also have renamed `SonoffSC.AirQuality` to `SonoffSC.SonoffSC.AirQuality` and so forth.

With kind regards,
Andreas.
